### PR TITLE
[10.4] Update Users remove method to add params array to support hard_delete

### DIFF
--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -181,13 +181,18 @@ class Users extends AbstractApi
     }
 
     /**
-     * @param int $id
+     * @param int   $id
+     * @param array $params {
+     *
+     *     @var bool   $hard_delete     If true, contributions that would usually be moved to the ghost user are
+     *                                  deleted instead, as well as groups owned solely by this user.
+     * }
      *
      * @return mixed
      */
-    public function remove(int $id)
+    public function remove(int $id, array $params = [])
     {
-        return $this->delete('users/'.self::encodePath($id));
+        return $this->delete('users/'.self::encodePath($id), $params);
     }
 
     /**


### PR DESCRIPTION
This adds the `$params` array to `Api/Users` `remove()` to support optional parameters.

In GitLab v9.3, `hard_delete` was added as an optional parameter to the `DELETE /users/:id` API endpoint.

* [GitLab API Documentation](https://docs.gitlab.com/ee/api/users.html#user-deletion)
* [GitLab API v9.3 Commit](https://gitlab.com/gitlab-org/gitlab/-/commit/c890c6aaf2939bc19292947bd8268d724fa7ddce)